### PR TITLE
Feature/map skus

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,5 +18,5 @@ android {
 }
 
 dependencies {
-    api 'com.appsflyer:af-android-sdk:4.8.7'
+    api 'com.appsflyer:af-android-sdk:4.8.14'
 }

--- a/src/main/java/com/mparticle/kits/AppsFlyerKit.java
+++ b/src/main/java/com/mparticle/kits/AppsFlyerKit.java
@@ -51,7 +51,6 @@ public class AppsFlyerKit extends KitIntegration implements KitIntegration.Event
      * This key will be present when returning a result from AppsFlyer's onAppOpenAttribution API
      */
     public static final String APP_OPEN_ATTRIBUTION_RESULT = "MPARTICLE_APPSFLYER_APP_OPEN_ATTRIBUTION_RESULT";
-    private AttributionResult mLatestConversionData, mLatestOpenData;
 
     @Override
     public Object getInstance() {
@@ -133,6 +132,7 @@ public class AppsFlyerKit extends KitIntegration implements KitIntegration.Event
                 }
             } else {
                 String eventName = event.getProductAction().equals(Product.CHECKOUT) ? AFInAppEventType.INITIATED_CHECKOUT : AFInAppEventType.PURCHASE;
+                eventValues.put(AFInAppEventParameterName.CONTENT_ID, AppsFlyerKit.generateProductIdList(event));
                 if (event.getProducts() != null && event.getProducts().size() > 0) {
                     double totalQuantity = 0;
                     for (Product product : event.getProducts()) {
@@ -170,6 +170,25 @@ public class AppsFlyerKit extends KitIntegration implements KitIntegration.Event
         }
 
         return messages;
+    }
+
+    static String generateProductIdList(CommerceEvent event) {
+        if (event == null || event.getProducts() == null || event.getProducts().size() == 0) {
+            return null;
+        }
+        StringBuilder productIdList = new StringBuilder();
+        for (Product product : event.getProducts()) {
+            String sku = product.getSku();
+            if (!KitUtils.isEmpty(sku)) {
+                productIdList.append(sku.replace(",","%2C"));
+                productIdList.append(",");
+            }
+        }
+        if (productIdList.length() > 0) {
+            return productIdList
+                    .substring(0, productIdList.length() - 1);
+        }
+        return null;
     }
 
     @Override
@@ -266,7 +285,6 @@ public class AppsFlyerKit extends KitIntegration implements KitIntegration.Event
         AttributionResult result = new AttributionResult()
                 .setParameters(jsonResult)
                 .setServiceProviderId(getConfiguration().getKitId());
-        mLatestConversionData = result;
         getKitManager().onResult(result);
 
     }
@@ -297,7 +315,6 @@ public class AppsFlyerKit extends KitIntegration implements KitIntegration.Event
         AttributionResult result = new AttributionResult()
                 .setParameters(jsonResult)
                 .setServiceProviderId(getConfiguration().getKitId());
-        mLatestOpenData = result;
         getKitManager().onResult(result);
     }
 

--- a/src/test/java/com/mparticle/kits/AppsflyerKitTests.java
+++ b/src/test/java/com/mparticle/kits/AppsflyerKitTests.java
@@ -3,13 +3,20 @@ package com.mparticle.kits;
 
 import android.content.Context;
 
+import com.mparticle.MParticle;
+import com.mparticle.commerce.CommerceEvent;
+import com.mparticle.commerce.Product;
+import com.mparticle.commerce.TransactionAttributes;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -54,5 +61,32 @@ public class AppsflyerKitTests {
             }
         }
         fail(className + " not found as a known integration.");
+    }
+
+    @Test
+    public void testGenerateSkuString() throws Exception {
+        MParticle.setInstance(Mockito.mock(MParticle.class));
+        Mockito.when(MParticle.getInstance().getEnvironment()).thenReturn(MParticle.Environment.Production);
+        assertNull(AppsFlyerKit.generateProductIdList(null));
+        Product product = new Product.Builder("foo-name", "foo-sku", 50).build();
+        CommerceEvent event = new CommerceEvent.Builder(Product.PURCHASE, product)
+                .transactionAttributes(new TransactionAttributes("foo"))
+                .build();
+        assertEquals("foo-sku", AppsFlyerKit.generateProductIdList(event));
+
+        Product product2 = new Product.Builder("foo-name-2", "foo-sku-2", 50).build();
+        CommerceEvent event2 = new CommerceEvent.Builder(Product.PURCHASE, product)
+                .addProduct(product2)
+                .transactionAttributes(new TransactionAttributes("foo"))
+                .build();
+        assertEquals("foo-sku,foo-sku-2", AppsFlyerKit.generateProductIdList(event2));
+
+        Product product3 = new Product.Builder("foo-name-3", "foo-sku-,3", 50).build();
+        CommerceEvent event3 = new CommerceEvent.Builder(Product.PURCHASE, product)
+                .addProduct(product2)
+                .addProduct(product3)
+                .transactionAttributes(new TransactionAttributes("foo"))
+                .build();
+        assertEquals("foo-sku,foo-sku-2,foo-sku-%2C3", AppsFlyerKit.generateProductIdList(event3));
     }
 }


### PR DESCRIPTION
This PR updates to the latest AppsFlyer SDK as well as maps `CommerceEvent` product SKUs to the `af_content_id` event attribute key as a comma-separated list. This is performed for Purchase and Checkout events, addition to the existing behavior for other `CommerceEvent` types.

Some assumptions are made:
1. If a SKU is null or zero-length, it's excluded entirely (rather than empty string)
2. Commas in SKUs are encoded.