### PR TITLE
fix: android events not forwarding to appsflyer

### DIFF
--- a/src/main/kotlin/com/mparticle/kits/AppsFlyerKit.kt
+++ b/src/main/kotlin/com/mparticle/kits/AppsFlyerKit.kt
@@ -335,7 +335,7 @@ class AppsFlyerKit : KitIntegration(), KitIntegration.EventListener,
 
     override fun onActivityCreated(
         activity: Activity,
-        bundle: Bundle
+        bundle: Bundle?
     ): List<ReportingMessage> {
         instance.start(activity)
         return emptyList()
@@ -351,7 +351,7 @@ class AppsFlyerKit : KitIntegration(), KitIntegration.EventListener,
 
     override fun onActivitySaveInstanceState(
         activity: Activity,
-        bundle: Bundle
+        bundle: Bundle?
     ): List<ReportingMessage> = emptyList()
 
     override fun onActivityDestroyed(activity: Activity): List<ReportingMessage> = emptyList()


### PR DESCRIPTION
## Summary
- Made bundle parameter in onActivityCreated and onActivitySavedInstance nullable.

## Testing Plan
- All tests passed and event are forwarded to mParticles dashboard as appsflyer output.

## Reference Issue
- Closes https://go.mparticle.com/work/SQDSDKS-4529
